### PR TITLE
Warn on the use of console

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+> A brief description of the problem or enhancement this PR addresses.
+
+## Usage
+
+> Are there any scenarios where a project might need to disable or change this
+> rule on a per-file or per-line basis? If so, consider documenting examples
+> here.
+
+## Tasks
+
+- [ ] Update [CHANGELOG] [💡][keepachangelog]
+
+## Reviewer Notes
+
+- Can projects that use the [latest] major version of `eslint-config-fk` update
+  without impact, or does this PR introduce a breaking change?
+
+## Links
+  
+- Links to any relevant ESLint rules
+
+[CHANGELOG]: https://github.com/fictivekin/eslint-config-fk/blob/master/CHANGELOG.md
+[keepachangelog]: https://keepachangelog.com
+[latest]: https://github.com/fictivekin/eslint-config-fk/releases/latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Disallow the use of `console`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Disallow the use of `console`
+- Warn on use of `console`

--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ module.exports = {
         "ignoreRegExpLiterals": true,
         "ignorePattern": true
       }
-    ]
+    ],
+    "no-console": "error",
   },
   "globals": {
     "__DEV__": false,

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
         "ignorePattern": true
       }
     ],
-    "no-console": "error",
+    "no-console": "warn",
   },
   "globals": {
     "__DEV__": false,


### PR DESCRIPTION
## Summary

- Adds `no-console` rule as `warn`, warning on use of `console` in all cases
- Adds a `CHANGELOG.md` and a pull request template to the project

Adding `no-console` as a warning could help catch any debugging uses of `console` calls before being committed or pushed.

## Usage

In cases where a console call is desired in non-debugging contexts, the rule can be disabled:

```javascript
// eslint-disable-next-line no-console
console.log("This message should be logged to an end-user's browser");
```

## Tasks

- [x] Update CHANGELOG

## Notes

ESLint on `console` use:

> In JavaScript that is designed to be executed in the browser, it’s considered a best practice to avoid using methods on console. Such messages are considered to be for debugging purposes and therefore not suitable to ship to the client.

## Links

- https://eslint.org/docs/latest/rules/no-console