### PR TITLE
Add `simple-import-sort` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `simple-import-sort/imports`
 
 ## v2.0.1
 ### Added

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = {
         }
       }
     ],
+    "simple-import-sort/imports": "error",
   },
   "globals": {
     "__DEV__": false,
@@ -56,5 +57,6 @@ module.exports = {
     "navigator": false,
     "FormData": false,
     "window": false
-  }
+  },
+  "plugins": ["simple-import-sort"],
 };

--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
   },
   "homepage": "https://github.com/fictivekin/eslint-config-fk#readme",
   "dependencies": {
-    "eslint-config-google": "^0.14.0"
+    "eslint-config-google": "^0.14.0",
+    "eslint-plugin-simple-import-sort": "^8.0.0"
   },
   "peerDependencies": {
     "eslint": ">= 3"
   },
-  "devDependencies": {
-    "eslint-plugin-simple-import-sort": "^8.0.0"
-  }
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   },
   "peerDependencies": {
     "eslint": ">= 3"
+  },
+  "devDependencies": {
+    "eslint-plugin-simple-import-sort": "^8.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,3 +6,8 @@ eslint-config-google@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.14.0.tgz#4f5f8759ba6e11b424294a219dbfa18c508bcc1a"
   integrity sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==
+
+eslint-plugin-simple-import-sort@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-8.0.0.tgz#9d9a2372b0606e999ea841b10458a370a6ccc160"
+  integrity sha512-bXgJQ+lqhtQBCuWY/FUWdB27j4+lqcvXv5rUARkzbeWLwea+S5eBZEQrhnO+WgX3ZoJHVj0cn943iyXwByHHQw==


### PR DESCRIPTION
## Summary

This PR adds the [`simple-import-sort`](https://www.npmjs.com/package/eslint-plugin-simple-import-sort) plugin and `simple-import-sort/imports` rule as an `error`.

## Usage

This plugin only supports ESM `import` statements. 

Projects that use CJS-style `require` statements should disable this rule (and, optionally, use a `require`-friendly plugin instead).

## Tasks

- [x] Update [CHANGELOG] [💡][keepachangelog]

## Reviewer Notes

This would introduce a new build-breaking `error` state, which may be a candidate for a major version bump

[CHANGELOG]: https://github.com/fictivekin/eslint-config-fk/blob/master/CHANGELOG.md
[keepachangelog]: https://keepachangelog.com
[latest]: https://github.com/fictivekin/eslint-config-fk/releases/latest
